### PR TITLE
Specify yarn version at 1.2

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,7 +21,7 @@ The process involves:
 - git
 - [node >= 6.9.5, < 8](https://nodejs.org/en/) (use [nvm](https://github.com/creationix/nvm) to upgrade/downgrade)
 - [npm](https://www.npmjs.com/get-npm)
-- [yarn](https://yarnpkg.com/lang/en/docs/install/)
+- [yarn ~= 1.2.x](https://yarnpkg.com/lang/en/docs/install/)
 
 Optionally, if you want to use the command line:
 


### PR DESCRIPTION
Yarn >= 1.3.x inexplicably fails on Centos/Debian (but apparently not OSX), 1.2.1 succeeds.   Presumably something broke in the 1 Nov release, the docs should reflect this until the issue is resolved.