### PR TITLE
Add troubleshooting notes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,6 +8,7 @@
 * [Deployment](docs/deployment.md)
   * [Creating an S3 Bucket](docs/create_bucket.md)
   * [Locating IAMs](docs/iam_roles.md)
+  * [Troubleshooting Deployment](docs/troubleshoot_deployment.md)
 * [Dockerization](docs/docker.md)
 * [Local Docs](docs/doc_installation.md)
 * [Team](docs/team.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -447,7 +447,7 @@ replace the default apiRoot `https://wjdkfyb6t6.execute-api.us-east-1.amazonaws.
     apiRoot: process.env.APIROOT || 'https://<czbbkscuy6>.execute-api.us-east-1.amazonaws.com/dev/'
 
 
-**Note**  evironmental variables are available during the build: `APIROOT`, `DAAC_NAME`, `STAGE`, `HIDE_PDR`, any of these can be set on the command line to override the values contained in `config.js` when running the build below.
+**Note**  environmental variables are available during the build: `APIROOT`, `DAAC_NAME`, `STAGE`, `HIDE_PDR`, any of these can be set on the command line to override the values contained in `config.js` when running the build below.
 
 
 Build the dashboard from the dashboard repository root directory, `cumulus-dashboard`:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,8 +26,6 @@ The process involves:
 - [yarn](https://yarnpkg.com/lang/en/docs/install/)
 - zip
 
-Optionally, if you want to use the command line, Amazon proivdes a CLI for interacting with AWS:
-
 - AWS CLI - [AWS command line interface](https://aws.amazon.com/cli/)
 - python
 
@@ -58,24 +56,25 @@ Change directory to the repository root
 
     $ cd cumulus
 
+Optionally, If you are deploying a particular version(tag), ref or branch of Cumulus core, you should check out that particular reference
+
+    $ git checkout \<ref/branch/tag\>
+
 Install and configure the local build environment and dependencies using npm
 
     $ npm install
-    $ npm run ybootstrap
+    $ npm run ybootstrap[Troubleshooting^4]
 
 Build the cumulus application
 
     $ npm run build
 
-
-**Note**: In-house SSL certificates may prevent successful bootstrap. (i.e. `PEM_read_bio` errors)
-
-
 #### Prepare DAAC deployment repository {#prepare-deployment}
 
-_If you already are working with an existing `<daac>-deploy` repository that is configured appropriately for the version of Cumulus you intend to deploy or update, skip to [Prepare AWS configuration. ](#prepare-config)_
+_If you already are working with an existing `<daac>-deploy` repository that is configured appropriately for the version of Cumulus you intend to deploy or update, skip to [Pre
+pare AWS configuration. ](#prepare-config)_
 
-Go to the same directory level as the cumulus repo download
+Go to the same directory level as the cumulus repo download (e.g. cumulus/..)
 
     $ cd ..
 
@@ -135,6 +134,8 @@ The following s3 buckets should be created (replacing prefix with whatever you'd
 * `<prefix>-protected`
 * `<prefix>-public`
 
+These buckets do not need any non-default permissions to function with Cumulus, however your local security requirements may vary.
+
 
 **Note**: s3 bucket object names are global and must be unique across all accounts/locations/etc.
 
@@ -156,7 +157,7 @@ __All deployments in the various config.yml files inherit from the `default` dep
         shared_data_bucket: cumulus-data-shared  # Devseed-managed shared bucket (contains custom ingest lmabda functions/common ancillary files)
 
 
-#####Deploy `deployer` stack**[^1]
+##### Deploy `deployer` stack**[^1]
 
 Use the kes utility installed with cumulus to deploy your configurations to AWS. This must be done from the <daac>-deploy repository root
 
@@ -247,8 +248,8 @@ These updates configure the [copied template](#copy-template) from the cumulus r
 You should either add a new root-level key for your configuration or modify the existing default configuration key to whatever you'd like your new deployment to be.
 
 If you're re-depoying based on an existing configuration you can skip this configuration step unless values have been updated *or* you'd like to add a new deployment to your deployment configuration file.
+
 =======
->>>>>>> develop
 
 **Edit the  `<daac>-deploy/app/config.yml` file **
 
@@ -259,11 +260,11 @@ The various configuration sections are described below with a sample `config.yml
 
 Configure your virtual private cloud.  You can find `<vpc-id>` and `<subnet-id>` values on the [VPC Dashboard](https://console.aws.amazon.com/vpc/home?region=us-east-1#). `vpcId` from [Your VPCs](https://console.aws.amazon.com/vpc/home?region=us-east-1#vpcs:), and `subnets` [here](https://console.aws.amazon.com/vpc/home?region=us-east-1#subnets:). When you choose a subnet, be sure to also note its availability zone, to configure `ecs`.
 
+
 ###### ecs
 
 Configuration for the Amazon EC2 Container Service (ECS) instance.  Update `availabilityZone` with information from [VPC Dashboard](https://console.aws.amazon.com/vpc/home?region=us-east-1#)
-note `instanceType` and `desiredInstances` have been selected for a sample install.  You will have to specify appropriate values to deploy and use ECS machines.
-
+note `instanceType` and `desiredInstances` have been selected for a sample install.  You will have to specify appropriate values to deploy and use ECS machines.   See [EC2 Instance Types](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html) for more information.
 
 ###### buckets
 
@@ -425,6 +426,7 @@ Also add the Distribution url `https://<kido2r7kji>.execute-api.us-east-1.amazon
   * AWS S3 console: Select `<prefix>-dashboard` bucket then, "Properties" -> "Static Website Hosting", point to `index.html`
   * CLI: `aws s3 website s3://<prefix>-dashboard --index-document index.html`
 * The bucket's url will be `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or you can find it on the AWS console via "Properties" -> "Static website hosting" -> "Endpoint"
+ * Ensure the bucket's access permissions allow your deployment user access to write to the bucket
 
 ### Install dashboard
 
@@ -464,8 +466,6 @@ Using AWS CLI:
 From the S3 Console:
 
 * Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
-
-
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
 `<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure Cumulus Stack](#configure-cumulus-stack) step.

--- a/docs/troubleshoot_deployment.md
+++ b/docs/troubleshoot_deployment.md
@@ -1,0 +1,43 @@
+# Troubleshooting Cumulus Deployment
+
+This document provides 'notes' on frequently encountered deployment issues.
+
+The issues reported are organized by relevant subsection, and *may* be out of date given the current rate of development.   Use at your own risk.
+
+## Deploy Cumulus
+### Installation
+Issues:
+
+- If you have a `PEM_read_bio` error when bootstrapping, SSL certificates may be to blame
+
+#### Configure Cumulus Stack
+##### vpc
+Issues:
+
+  - If redeploying an existing configuration you may already have at least 1 vpc associated with your existing deployment, but its subnets can be transitory in nature depending on what kind of load balancing and/or docker activities are taking place at a given time.  You should  identify at least one persistent subnet to use as a subnet ID (you may only specify one) for use.    If this is needed, navigate to  [AWS EC2 > Auto Scaling Groups](https://console.aws.amazon.com/ec2/autoscaling/home) and note the "Availibility Zone" (e.g., us-east-1a). Next, visit [AWS VPC](https://console.aws.amazon.com/vpc/home) and click on "Subnets". Copy the 'VPC' value into 'vpcId' and the appropriate 'Subnet ID' value, based on the Availability Zone value you just saw on the Auto Scaling Groups page, into 'subnets'. If you have no vpc and/or subnets, do not include the vpc section in your new configuration.
+
+  - If you see the error "The availability zones of the specified subnets and the Auto Scaling group do not match" in AWS > CloudFormation > Stacks > Stack Detail > Events appears while this stack is being deployed, it means you've chosen a subnet that isn't correct; this could be due to load balancing happening at different times. Try to use the approach above (but if this fails, you can try picking the "1a" subnet, which seems to serve as some sort of default).
+
+#### Deploy the Cumulus Stack
+
+Monitoring the progress of stack deployment can be done from the [AWS CloudFormation Console](https://console.aws.amazon.com/cloudformation/home).
+
+Issues:
+
+-  **Error:** __"The availability zones of the specified subnets and the Auto Scaling group do not match"__ -- You may have chosen the wrong subnet for your vpc. All but one of the subnets are transitory, only existing when various load balancing and/or docker operations are taking place. Thus, you must choose the one and only persistent subnet. Navigate to [AWS EC2 > Auto Scaling Groups](https://console.aws.amazon.com/ec2/autoscaling/home) and note the Availibility Zones (probably us-east-1a). Use that information in conjunction with [AWS VPC > Subnets](https://console.aws.amazon.com/vpc/home) to select the subnet ID corresponding to the correct availability zone (e.g., the subnet for "us-east-1a".
+
+- **The deployment isn't failing but is taking a long time**, navigate to [AWS ECS](https://console.aws.amazon.com/ecs/home) and then to "Clusters". Identify the new cluster associated with your <prefix> app deployment and click on it. The summary table (shown at bottom) for the cluster probably says "Desired tasks 1", or some other non-zero number, and "Running tasks 0". Click Update, then update the cluster to change "Number of tasks" to 0, or else you will receive (eventually) an error such as __"Service arn:aws:ecs:us-east-1:numbers:service/<prefix>-cumulus-<ECS service name> did not stabilize"__ and your app deployment will fail.
+
+- **If AWS stack rollback/deletion fails** , check for a failure to delete named State Machines that this stack created. The names of the specific state machines can be gathered from the "Events" section of the stack's output on the AWS CloudFormation Console; you can then (carefully) manually delete the specified State Machines, thus readying AWS for the next attempt.
+
+### Install dashboard
+#### Dashboard configuration
+Issues:
+-  __Problem clearing the cache: EACCES: permission denied, rmdir '/tmp/gulp-cache/default'__", this probably means the files at that location, and/or the folder, are owned by someone else (or some other factor prevents you from writing there).
+
+  It's possible to workaround this by editing the file `cumulus-dashboard/node_modules/gulp-cache/index.js` and alter the value of the line `var fileCache = new Cache({cacheDirName: 'gulp-cache'});` to something like, say, `var fileCache = new Cache({cacheDirName: '<prefix>-cache'});`. Now gulp-cache will be able to write to `/tmp/<prefix>-cache/default`, and the error should go away.
+
+#### Dashboard deployment
+Issues:
+- If the dashboard sends you to an Earthdata Login page that has an error reading __"Invalid request, please verify the client status or redirect_uri before resubmitting"__, this means you've either forgotten to update one or more of your EARTHDATA_CLIENT_ID, EARTHDATA_CLIENT_PASSWORD, or APIROOT environmental variables (see above), or you haven't placed the correct values in them, or you've forgotten to add both the "redirect" and "token" URL to the Earthdata Application.
+- There is odd caching behavior associated with the dashboard and Earthdata Login at this point in time that can cause the above error to reappear on the Earthdata Login page loaded by the dashboard even after fixing the cause of the error. If you experience this, attempt to access the dashboard in a new browser window, and it should work.

--- a/docs/troubleshoot_deployment.md
+++ b/docs/troubleshoot_deployment.md
@@ -12,11 +12,10 @@ Issues:
 
 #### Configure Cumulus Stack
 ##### vpc
+
 Issues:
 
   - If redeploying an existing configuration you may already have at least 1 vpc associated with your existing deployment, but its subnets can be transitory in nature depending on what kind of load balancing and/or docker activities are taking place at a given time.  You should  identify at least one persistent subnet to use as a subnet ID (you may only specify one) for use.    If this is needed, navigate to  [AWS EC2 > Auto Scaling Groups](https://console.aws.amazon.com/ec2/autoscaling/home) and note the "Availibility Zone" (e.g., us-east-1a). Next, visit [AWS VPC](https://console.aws.amazon.com/vpc/home) and click on "Subnets". Copy the 'VPC' value into 'vpcId' and the appropriate 'Subnet ID' value, based on the Availability Zone value you just saw on the Auto Scaling Groups page, into 'subnets'. If you have no vpc and/or subnets, do not include the vpc section in your new configuration.
-
-  - If you see the error "The availability zones of the specified subnets and the Auto Scaling group do not match" in AWS > CloudFormation > Stacks > Stack Detail > Events appears while this stack is being deployed, it means you've chosen a subnet that isn't correct; this could be due to load balancing happening at different times. Try to use the approach above (but if this fails, you can try picking the "1a" subnet, which seems to serve as some sort of default).
 
 #### Deploy the Cumulus Stack
 
@@ -24,7 +23,7 @@ Monitoring the progress of stack deployment can be done from the [AWS CloudForma
 
 Issues:
 
--  **Error:** __"The availability zones of the specified subnets and the Auto Scaling group do not match"__ -- You may have chosen the wrong subnet for your vpc. All but one of the subnets are transitory, only existing when various load balancing and/or docker operations are taking place. Thus, you must choose the one and only persistent subnet. Navigate to [AWS EC2 > Auto Scaling Groups](https://console.aws.amazon.com/ec2/autoscaling/home) and note the Availibility Zones (probably us-east-1a). Use that information in conjunction with [AWS VPC > Subnets](https://console.aws.amazon.com/vpc/home) to select the subnet ID corresponding to the correct availability zone (e.g., the subnet for "us-east-1a".
+-  **Error:** __"The availability zones of the specified subnets and the Auto Scaling group do not match"__ -- see [vpc issues](#vpc)
 
 - **The deployment isn't failing but is taking a long time**, navigate to [AWS ECS](https://console.aws.amazon.com/ecs/home) and then to "Clusters". Identify the new cluster associated with your <prefix> app deployment and click on it. The summary table (shown at bottom) for the cluster probably says "Desired tasks 1", or some other non-zero number, and "Running tasks 0". Click Update, then update the cluster to change "Number of tasks" to 0, or else you will receive (eventually) an error such as __"Service arn:aws:ecs:us-east-1:numbers:service/<prefix>-cumulus-<ECS service name> did not stabilize"__ and your app deployment will fail.
 

--- a/docs/troubleshoot_deployment.md
+++ b/docs/troubleshoot_deployment.md
@@ -34,9 +34,10 @@ Issues:
 Issues:
 -  __Problem clearing the cache: EACCES: permission denied, rmdir '/tmp/gulp-cache/default'__", this probably means the files at that location, and/or the folder, are owned by someone else (or some other factor prevents you from writing there).
 
-  It's possible to workaround this by editing the file `cumulus-dashboard/node_modules/gulp-cache/index.js` and alter the value of the line `var fileCache = new Cache({cacheDirName: 'gulp-cache'});` to something like, say, `var fileCache = new Cache({cacheDirName: '<prefix>-cache'});`. Now gulp-cache will be able to write to `/tmp/<prefix>-cache/default`, and the error should go away.
+  It's possible to workaround this by editing the file `cumulus-dashboard/node_modules/gulp-cache/index.js` and alter the value of the line `var fileCache = new Cache({cacheDirName: 'gulp-cache'});` to something like `var fileCache = new Cache({cacheDirName: '<prefix>-cache'});`. Now gulp-cache will be able to write to `/tmp/<prefix>-cache/default`, and the error should resolve.
 
 #### Dashboard deployment
 Issues:
-- If the dashboard sends you to an Earthdata Login page that has an error reading __"Invalid request, please verify the client status or redirect_uri before resubmitting"__, this means you've either forgotten to update one or more of your EARTHDATA_CLIENT_ID, EARTHDATA_CLIENT_PASSWORD, or APIROOT environmental variables (see above), or you haven't placed the correct values in them, or you've forgotten to add both the "redirect" and "token" URL to the Earthdata Application.
+- If the dashboard sends you to an Earthdata Login page that has an error reading __"Invalid request, please verify the client status or redirect_uri before resubmitting"__, this means you've either forgotten to update one or more of your EARTHDATA_CLIENT_ID, EARTHDATA_CLIENT_PASSWORD environment variables (from your app/.env file) and re-deploy Cumulus, or you haven't placed the correct values in theml, or you've forgotten to add both the "redirect" and "token" URL to the Earthdata Application.
+
 - There is odd caching behavior associated with the dashboard and Earthdata Login at this point in time that can cause the above error to reappear on the Earthdata Login page loaded by the dashboard even after fixing the cause of the error. If you experience this, attempt to access the dashboard in a new browser window, and it should work.


### PR DESCRIPTION
Added a troubleshoot_deployment subpage to the deployment documents, pulled notes/troubleshooting content from https://github.com/cumulus-nasa/cumulus-nasa.github.io/pull/20

Given the nature of the PR, I'm including notes on the inclusions/exclusions from the original content for posterity: 

```L23 — Left out, install instructions are on first page of link

L53-L62 — Team agreed to not add detailed documentation on AWS permissions as part of this effort.   Need a new story? 

L73 - Feels too specific to generic documentation.    Consider adding a note to make sure you’re on the correct branch. 

L75 — Moved to troubleshooting

L81 -- Covered by `Go to the same directory level as the cumulus repo download (e.g. cumulus/..)`

L88 — Not including, it’s DAAC specific documentation and may change/be different depending on target DAAC 

L90 -- Covered in the Overview, as well as the linked KES documentation

L105 — Covered in the create_buckets page, however added a comment that default permissions will work for Cumulus buckets

L141 --  Current versions of Cumulus *should* work from either a manual global install or the project directory

L236  —  Based on our current understanding, many of these additional fields are not required for a default installation.    Capturing this falls outside of the scope of the initial documentation effort, however documentation of this may be needed as things proceed.   

L246-248:  Included this note in the troubleshooting section

L264:  Added, however the troubleshooting caveat needs to be investigated - is this still a bug?   If it is it should be a ticket and perhaps that should be referenced. 

L335-344 - Included in troubleshooting document

L432:  Add to baseline documentation

L439 - Include in troubleshooting document

L443 — Included comment in dashboard s3 bucket creation instructions to ensure deployment user has access. 

L453 — Included in troubleshooting page

L455 — Included in troubleshooting page```
